### PR TITLE
Handle Naming Convention Inconsistency in User Defined Bands Input

### DIFF
--- a/solafune_tools/pipeline.py
+++ b/solafune_tools/pipeline.py
@@ -62,8 +62,17 @@ def create_basemap(
     )
 
     if bands == 'Auto':
-        bands = ['B01', 'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B09', 'B11', 'B12']
-        
+        bands = solafune_tools.settings.get_valid_bands()
+    else:
+        valid_bands = solafune_tools.settings.get_valid_bands()
+        if isinstance(bands, str):
+            if bands not in valid_bands:
+                raise ValueError(f"Invalid band {bands}. Valid bands are {valid_bands}")
+        elif isinstance(bands, list):
+            for band in bands:
+                if band not in valid_bands:
+                    raise ValueError(f"Invalid band {band}. Valid bands are {valid_bands}")
+                
     tiffile_dir = solafune_tools.image_fetcher.planetary_computer_fetch_images(
         dataframe_path=plc_stac_catalog,
         bands=bands,

--- a/solafune_tools/settings.py
+++ b/solafune_tools/settings.py
@@ -21,3 +21,7 @@ def get_data_directory():
     if os.getenv("solafune_tools_data_dir") is None:
         set_data_directory()
     return os.getenv("solafune_tools_data_dir")
+
+def get_valid_bands():
+    """Returns a list of valid bands for Sentinel-2"""
+    return ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]


### PR DESCRIPTION
This pull request addresses a potential naming convention inconsistency in user-defined bands input when using the `create_basemap` function. When the bands parameter is set to "Auto", the function automatically populates the list of bands with the standard Sentinel-2 band names (e.g., 'B01', 'B02', ..., 'B12'). However, if the user sets the bands individually, there is a possibility of naming errors, such as using lowercase letters or abbreviated band names (e.g., 'b1' instead of 'B01').

To mitigate this inconsistency, I've implemented additional logic in the function to handle such cases. Now, when the bands parameter is set manually, the function checks each band name so that it is in accordance to the standard Sentinel-2 naming convention. If any discrepancies are found, it will raise an error and give the valid bands options. I've added a `get_valid_bands()` function in `settings.py` to ensure code reusability and centralize band name validation. 

This pull request not only handle naming convention inconsistency before fetching the image, but also prevents the `_setup_directories()` function on `image_fetcher.py` from creating an unnecessary empty directory.