### PR TITLE
Fix F1 metric calculation in edge cases where neither predicted polygons nor ground truth polygons are present

### DIFF
--- a/solafune_tools/metrics.py
+++ b/solafune_tools/metrics.py
@@ -137,7 +137,7 @@ class F1_Metrics:
         tp = len(matched_instances)
         fp = len(pred_polygons) - tp
         fn = len(gt_polygons) - tp
-        precision = tp / (tp + fp) if (tp + fp) > 0 else 0
-        recall = tp / (tp + fn) if (tp + fn) > 0 else 0
-        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 1  # if no prediction, precision is considered as 1
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 1  # if no ground truth, recall is considered as 1
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0  # if either precision or recall is 0, f1 is 0
         return f1, precision, recall

--- a/solafune_tools/metrics.py
+++ b/solafune_tools/metrics.py
@@ -137,7 +137,7 @@ class F1_Metrics:
         tp = len(matched_instances)
         fp = len(pred_polygons) - tp
         fn = len(gt_polygons) - tp
-        precision = tp / (tp + fp) if (tp + fp) > 0 else 1  # if no prediction, precision is considered as 1
-        recall = tp / (tp + fn) if (tp + fn) > 0 else 1  # if no ground truth, recall is considered as 1
-        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0  # if either precision or recall is 0, f1 is 0
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0  # if no prediction, precision is considered as 1
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0  # if no ground truth, recall is considered as 1
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0  # if either precision or recall is 0, f1 is 0
         return f1, precision, recall


### PR DESCRIPTION
Before this PR applied,

```python
from shapely.geometry import Polygon
from solafune_tools.metrics import F1_Metrics

metric = F1_Metrics()

f1, precision, recall = metric.compute_f1(
    gt_polygons=[],  # no truth polygons
    pred_polygons=[
        Polygon([(1, 2), (2, 4), (3, 1)]),
        Polygon([(0, 0), (1, 3), (2, 2), (3, 0)]),
        Polygon([(5, 5), (6, 6), (7, 5), (8, 4), (5, 3)]),
],  # some predicted polygons (all false positives)
)

print(f"{f1=}, {precision=}, {recall=}")  # f1=0, precision=0.0, recall=0
```

```python
from shapely.geometry import Polygon
from solafune_tools.metrics import F1_Metrics

metric = F1_Metrics()

f1, precision, recall = metric.compute_f1(
    gt_polygons=[],  # no truth polygons
    pred_polygons=[],  # no predicted polygons (i.e., correct prediction)
)

print(f"{f1=}, {precision=}, {recall=}")  # f1=0, precision=0, recall=0
```

After this PR applied,

```python
from shapely.geometry import Polygon
from solafune_tools.metrics import F1_Metrics

metric = F1_Metrics()

f1, precision, recall = metric.compute_f1(
    gt_polygons=[],  # no truth polygons
    pred_polygons=[
        Polygon([(1, 2), (2, 4), (3, 1)]),
        Polygon([(0, 0), (1, 3), (2, 2), (3, 0)]),
        Polygon([(5, 5), (6, 6), (7, 5), (8, 4), (5, 3)]),
],  # some predicted polygons (all false positives)
)

print(f"{f1=}, {precision=}, {recall=}")  # f1=0, precision=0.0, recall=1.0
```

```python
from shapely.geometry import Polygon
from solafune_tools.metrics import F1_Metrics

metric = F1_Metrics()

f1, precision, recall = metric.compute_f1(
    gt_polygons=[],  # no truth polygons
    pred_polygons=[],  # no predicted polygons (i.e., correct prediction)
)

print(f"{f1=}, {precision=}, {recall=}")  # f1=1.0, precision=1.0, recall=1.0
```