### PR TITLE
Add raster_regression community tools: submission validation, zip-level ensembling, isotonic calibration

### DIFF
--- a/docs/community_tools/README.md
+++ b/docs/community_tools/README.md
@@ -4,4 +4,4 @@ This side of this repository act as where Solafune hackers can put the documenta
 
 ## Community Tools List
 
-1. [Your Tool Name](your-tool-name.md)
+1. [Raster Regression Tools](raster_regression.md)

--- a/docs/community_tools/raster_regression.md
+++ b/docs/community_tools/raster_regression.md
@@ -1,0 +1,142 @@
+# Raster Regression Tools — Usage
+
+Tools for competitions scored on zip archives of GeoTIFF tiles (raster regression).
+Everything below needs only `numpy`, `rasterio`, and `tqdm` (already in the base
+requirements).
+
+```python
+from solafune_tools.community_tools.raster_regression import (
+    validate_submission_zip,
+    return_error_message,
+    band_count_report,
+    blend_submission_zips,
+    IsotonicCalibrator,
+    calibrate_submission_zip,
+)
+```
+
+## 1. Validate a submission before uploading
+
+Check your prediction archive against the competition's sample submission. This catches
+the mistakes that either get a submission rejected or silently scored as garbage:
+missing/misnamed tiles, wrong grid shape, NaN/Inf pixels, negative values.
+
+```python
+code, report = validate_submission_zip(
+    "my_submission.zip",
+    reference_zip_path="sample_submission.zip",  # tile names + shapes come from here
+    value_min=0.0,                               # rain rate can't be negative
+)
+print(return_error_message(code))   # "Valid" when code == 0
+print(report["stats"])              # n_tiles, value min/max/mean, all-zero tile count
+```
+
+Error codes (mirrors the `competition_tools.quality_checker` convention):
+
+| code | meaning |
+|------|---------|
+| 0    | valid |
+| 30   | cannot open the zip archive |
+| 31   | no `.tif` files inside |
+| 32   | tile count mismatch vs. reference |
+| 33   | tile names don't match reference |
+| 34   | unreadable tile |
+| 35   | unexpected raster shape |
+| 36   | NaN/Inf pixels |
+| 37   | values outside the allowed range |
+
+On failure, `report` lists the offending files (capped at 20 per problem).
+`report["warnings"]` carries non-fatal observations (e.g. many all-zero tiles).
+
+Without a reference archive, pass `expected_shape=(41, 41)` (or `(bands, H, W)`) to pin
+shapes explicitly.
+
+## 2. Blend submissions (zip-level ensembling)
+
+Averaging diverse predictions is the most reliable free score improvement in regression
+competitions, and doing it on the submission artifacts means no re-inference and no
+pipeline coupling — you can blend this week's model with last week's.
+
+```python
+blend_submission_zips(
+    ["model_a.zip", "model_b.zip"],
+    out_path="blend_ab.zip",
+)                                          # equal weights
+
+blend_submission_zips(
+    ["model_a.zip", "model_b.zip", "model_c.zip"],
+    out_path="blend_abc.zip",
+    weights=[2, 1, 1],                     # normalized automatically
+    clip_min=0.0,                          # keep physical validity after averaging
+)
+```
+
+Tiles are matched by base file name, geo metadata is copied from the first archive, and
+tiles stream one at a time so memory use stays flat.
+
+**Tip:** blending helps most when the inputs are *diverse* (different architectures,
+feature sets, or training configs) and roughly comparable in score. Two strong-but-
+different submissions usually beat either one alone; ten near-copies of the same model
+do not add much.
+
+## 3. Isotonic output calibration
+
+Models trained with MSE-family losses on skewed targets (rainfall, biomass, cost)
+systematically under-predict the high tail. Isotonic calibration learns a monotone
+correction from *held-out* predictions and applies it as a post-process.
+
+```python
+# 1) Fit on out-of-fold predictions (never on training-set predictions!)
+cal = IsotonicCalibrator(n_bins=64).fit(oof_pred, oof_true)   # any-shape arrays
+
+# 2) Apply to arrays...
+test_pred_calibrated = cal.transform(test_pred)
+
+# ...or directly to a submission archive
+calibrate_submission_zip("my_submission.zip", "my_submission_cal.zip", cal)
+
+# 3) Persist for reproducibility
+cal.save("calibration.json")
+cal = IsotonicCalibrator.load("calibration.json")
+```
+
+When your data mixes sources with different error profiles (e.g. three geostationary
+satellites), fit one calibrator per source and route tiles by file name:
+
+```python
+cals = {
+    "himawari": IsotonicCalibrator().fit(oof_pred_him, oof_true_him),
+    "goes":     IsotonicCalibrator().fit(oof_pred_goes, oof_true_goes),
+    "meteosat": IsotonicCalibrator().fit(oof_pred_met, oof_true_met),
+}
+calibrate_submission_zip(
+    "my_submission.zip", "calibrated.zip",
+    calibrator=cals,
+    group_fn=lambda name: next(s for s in cals if s in name.lower()),
+)
+```
+
+Implementation notes: predictions are quantile-binned (`n_bins`), bin means are made
+monotone with the pool-adjacent-violators algorithm, and the mapping is linearly
+interpolated between bin centers with flat extrapolation outside the fitted range.
+No scikit-learn dependency.
+
+## 4. Find tiles with missing bands
+
+Multi-band competition tiles sometimes ship with fewer bands than nominal, and the
+GeoTIFF format does not record *which* bands are absent — naive `array[channel_i]`
+indexing then reads the wrong band for every channel of that tile. Scan for such tiles
+once and decide how to handle them (exclude, special-case, or query the host):
+
+```python
+deviant = band_count_report("evaluation_dataset/", expected_bands=16)
+for path, count, shape in deviant:
+    print(path, count, shape)
+```
+
+## Provenance
+
+Extracted and generalized from the authors' pipeline in the *Precipitation Nowcasting
+From Space* competition, where zip-level blending and per-satellite isotonic
+calibration each improved leaderboard RMSE. Original code; PAVA follows Barlow et al.
+(1972). Developed with assistance from Claude (Anthropic).

--- a/solafune_tools/community_tools/README.md
+++ b/solafune_tools/community_tools/README.md
@@ -34,4 +34,4 @@ Tools repository where Solafune hackers can share their tools on satellite data-
 
 ## Listed Community Tools
 
-Currently, there are no community tools that can be listed. We hope for your contribution.
+1. [Raster Regression Tools](raster_regression/README.md) — submission validation, zip-level ensembling, and isotonic calibration for GeoTIFF-zip regression competitions.

--- a/solafune_tools/community_tools/raster_regression/README.md
+++ b/solafune_tools/community_tools/raster_regression/README.md
@@ -1,0 +1,51 @@
+# Raster Regression Tools
+
+## Description
+
+Utilities for competitions scored on **zip archives of GeoTIFF tiles** (raster
+regression), such as *Precipitation Nowcasting From Space*. The existing
+`competition_tools` validators cover JSON (detection/segmentation) and CSV
+submissions; this module fills the raster gap with three things every raster-regression
+participant ends up re-implementing:
+
+1. **`validate_submission_zip`** — pre-upload submission checking (tile count/names vs.
+   the sample submission, raster shape, NaN/Inf, negative values) with
+   `quality_checker`-style error codes. Catches format rejects *before* they burn a
+   daily submission slot.
+2. **`blend_submission_zips`** — pixel-wise (weighted) averaging of N submission
+   archives. Ensembling at the artifact level works across pipelines and frameworks
+   with no re-inference; blending two diverse submissions typically beats both inputs.
+3. **`IsotonicCalibrator` / `calibrate_submission_zip`** — dependency-free isotonic
+   (PAVA) output calibration fit on out-of-fold predictions, with optional per-group
+   (e.g. per-satellite) calibrators. Corrects the systematic tail under-prediction of
+   MSE-trained models on skewed targets.
+
+A small `band_count_report` helper is included to locate dataset tiles whose band
+count deviates from nominal (e.g. GOES tiles missing their visible channels), since
+GeoTIFFs carry no record of *which* bands are absent and silent positional
+misalignment is easy to hit.
+
+## Impact to the data and Example of the dataset
+
+These tools operate on prediction artifacts and datasets of any raster regression
+competition (single- or multi-band GeoTIFF tiles, any grid size):
+
+- Validation prevents malformed uploads (wrong tile set, NaN pixels, negative
+  precipitation) from wasting quota or scoring as garbage.
+- Blending and calibration are direct, generic score improvements: in the
+  Precipitation Nowcasting From Space competition, a 50/50 blend of two diverse
+  submissions and per-satellite isotonic calibration each improved leaderboard RMSE
+  for the authors' pipeline.
+
+## Usage Documentation
+
+Refer to this [link](/docs/community_tools/raster_regression.md) for the usage of this tool.
+
+## Attribution
+
+Isotonic regression via pool-adjacent-violators follows Barlow, Bartholomew, Bremner &
+Brunk (1972), *Statistical Inference under Order Restrictions*. Original implementation
+for this module; developed with assistance from Claude (Anthropic) during the
+Precipitation Nowcasting From Space competition.
+
+Contact: open an issue on this repository.

--- a/solafune_tools/community_tools/raster_regression/__init__.py
+++ b/solafune_tools/community_tools/raster_regression/__init__.py
@@ -1,0 +1,19 @@
+from solafune_tools.community_tools.raster_regression.validation import (
+    validate_submission_zip,
+    band_count_report,
+    return_error_message,
+)
+from solafune_tools.community_tools.raster_regression.ensemble import blend_submission_zips
+from solafune_tools.community_tools.raster_regression.calibration import (
+    IsotonicCalibrator,
+    calibrate_submission_zip,
+)
+
+__all__ = [
+    "validate_submission_zip",
+    "band_count_report",
+    "return_error_message",
+    "blend_submission_zips",
+    "IsotonicCalibrator",
+    "calibrate_submission_zip",
+]

--- a/solafune_tools/community_tools/raster_regression/calibration.py
+++ b/solafune_tools/community_tools/raster_regression/calibration.py
@@ -1,0 +1,181 @@
+"""Isotonic output calibration for raster regression predictions.
+
+Regression models trained with MSE-family losses on skewed targets (rainfall, biomass,
+cost, ...) are systematically miscalibrated: they under-predict the high tail and
+over-predict near zero. Isotonic regression learns a monotone mapping from predicted
+to observed values on held-out (out-of-fold) data and applies it as a post-process —
+a few lines that reliably buy RMSE without touching the model.
+
+The fit uses the classic pool-adjacent-violators algorithm (PAVA; Barlow et al., 1972,
+"Statistical Inference under Order Restrictions") on quantile-binned predictions, so it
+needs only numpy and is O(n log n) in the number of held-out samples.
+"""
+
+import json
+import os
+import zipfile
+from io import BytesIO
+from typing import Callable, Dict, Optional, Union
+
+import numpy as np
+from tqdm import tqdm
+
+from rasterio.io import MemoryFile
+
+from solafune_tools.community_tools.raster_regression.validation import _tif_names
+
+
+def _pava(y: np.ndarray, w: np.ndarray):
+    """Weighted pool-adjacent-violators: least-squares non-decreasing fit to y.
+
+    Returns the pooled block values and block weights; expanding blocks back to
+    the original positions is the caller's job (block weights are sums of the
+    input weights they absorbed).
+    """
+    level_y = y.astype("float64").copy()
+    level_w = w.astype("float64").copy()
+    n = len(level_y)
+    i = 0
+    while i < n - 1:
+        if level_y[i] <= level_y[i + 1] + 1e-15:
+            i += 1
+            continue
+        # merge violating neighbors into one block at their weighted mean
+        wsum = level_w[i] + level_w[i + 1]
+        level_y[i] = (level_y[i] * level_w[i] + level_y[i + 1] * level_w[i + 1]) / wsum
+        level_w[i] = wsum
+        level_y = np.delete(level_y, i + 1)
+        level_w = np.delete(level_w, i + 1)
+        n -= 1
+        # a merge can violate the previous pair — step back
+        if i > 0:
+            i -= 1
+    return level_y, level_w
+
+
+class IsotonicCalibrator:
+    """Monotone (isotonic) mapping fit on held-out predictions vs. ground truth.
+
+    Usage::
+
+        cal = IsotonicCalibrator(n_bins=64).fit(oof_pred, oof_true)
+        test_pred_calibrated = cal.transform(test_pred)
+        cal.save("calibration.json")   # later: IsotonicCalibrator.load(...)
+
+    Fit on *out-of-fold* predictions only — calibrating on training-set predictions
+    just memorizes residual noise.
+    """
+
+    def __init__(self, n_bins: int = 64):
+        self.n_bins = int(n_bins)
+        self.x_: Optional[np.ndarray] = None  # bin-mean predictions (knots)
+        self.y_: Optional[np.ndarray] = None  # isotonic bin-mean targets
+
+    def fit(self, y_pred: np.ndarray, y_true: np.ndarray) -> "IsotonicCalibrator":
+        """Fit the mapping from flattened predictions to flattened targets."""
+        p = np.asarray(y_pred, dtype="float64").ravel()
+        t = np.asarray(y_true, dtype="float64").ravel()
+        if p.shape != t.shape:
+            raise ValueError("y_pred and y_true must have the same number of elements.")
+        if p.size < self.n_bins * 2:
+            raise ValueError(f"Need at least {self.n_bins * 2} samples to fit {self.n_bins} bins.")
+
+        edges = np.unique(np.quantile(p, np.linspace(0.0, 1.0, self.n_bins + 1)))
+        if len(edges) < 3:  # near-constant predictions: single global shift
+            self.x_ = np.array([p.min(), p.max() + 1e-9])
+            self.y_ = np.array([t.mean(), t.mean()])
+            return self
+        idx = np.clip(np.searchsorted(edges, p, side="right") - 1, 0, len(edges) - 2)
+
+        counts = np.bincount(idx, minlength=len(edges) - 1).astype("float64")
+        keep = counts > 0
+        mean_p = np.bincount(idx, weights=p, minlength=len(edges) - 1)[keep] / counts[keep]
+        mean_t = np.bincount(idx, weights=t, minlength=len(edges) - 1)[keep] / counts[keep]
+
+        level_y, level_w = _pava(mean_t, counts[keep])
+        # expand pooled levels back onto the kept bins
+        y_iso = np.empty_like(mean_t)
+        pos = 0
+        remaining = counts[keep].copy()
+        for ly, lw in zip(level_y, level_w):
+            acc = 0.0
+            while pos < len(y_iso) and acc < lw - 1e-9:
+                y_iso[pos] = ly
+                acc += remaining[pos]
+                pos += 1
+        self.x_, self.y_ = mean_p, y_iso
+        return self
+
+    def transform(self, y_pred: np.ndarray) -> np.ndarray:
+        """Apply the fitted mapping (flat extrapolation beyond the fitted range)."""
+        if self.x_ is None:
+            raise RuntimeError("Calibrator is not fitted.")
+        p = np.asarray(y_pred, dtype="float64")
+        return np.interp(p, self.x_, self.y_).astype(y_pred.dtype if
+                                                     np.issubdtype(np.asarray(y_pred).dtype, np.floating)
+                                                     else "float64")
+
+    def save(self, path: str) -> None:
+        with open(path, "w") as f:
+            json.dump({"n_bins": self.n_bins, "x": self.x_.tolist(), "y": self.y_.tolist()}, f)
+
+    @classmethod
+    def load(cls, path: str) -> "IsotonicCalibrator":
+        with open(path) as f:
+            d = json.load(f)
+        cal = cls(n_bins=d["n_bins"])
+        cal.x_ = np.asarray(d["x"], dtype="float64")
+        cal.y_ = np.asarray(d["y"], dtype="float64")
+        return cal
+
+
+def calibrate_submission_zip(
+    in_zip_path: str,
+    out_zip_path: str,
+    calibrator: Union[IsotonicCalibrator, Dict[str, IsotonicCalibrator]],
+    group_fn: Optional[Callable[[str], str]] = None,
+    clip_min: Optional[float] = 0.0,
+    clip_max: Optional[float] = None,
+    progress: bool = True,
+) -> str:
+    """Apply isotonic calibration to every tile of a submission archive.
+
+    Args:
+        in_zip_path: Submission archive to calibrate.
+        out_zip_path: Calibrated archive to write.
+        calibrator: A fitted :class:`IsotonicCalibrator`, or a dict of them keyed by
+            group name for per-group calibration (e.g. one per satellite/sensor).
+        group_fn: Maps a tile base name to its group key. Required when
+            ``calibrator`` is a dict. Tiles whose group has no calibrator pass
+            through unchanged.
+        clip_min / clip_max: Clip applied after calibration (default floor 0.0).
+        progress: Show a tqdm progress bar.
+
+    Returns:
+        ``out_zip_path``.
+    """
+    grouped = isinstance(calibrator, dict)
+    if grouped and group_fn is None:
+        raise ValueError("group_fn is required when calibrator is a dict.")
+
+    with zipfile.ZipFile(in_zip_path) as zin, \
+            zipfile.ZipFile(out_zip_path, "w", zipfile.ZIP_DEFLATED) as zout:
+        names = sorted(_tif_names(zin))
+        if not names:
+            raise ValueError(f"No .tif files found in {in_zip_path}")
+        for name in tqdm(names, desc="calibrate", disable=not progress):
+            with MemoryFile(BytesIO(zin.read(name))) as mem:
+                with mem.open() as src:
+                    arr = src.read().astype("float64")
+                    profile = src.profile.copy()
+            cal = calibrator.get(group_fn(os.path.basename(name))) if grouped else calibrator
+            if cal is not None:
+                arr = cal.transform(arr)
+            if clip_min is not None or clip_max is not None:
+                arr = np.clip(arr, clip_min, clip_max)
+            dtype = profile.get("dtype", "float32")
+            with MemoryFile() as mem:
+                with mem.open(**profile) as dst:
+                    dst.write(arr.astype(dtype))
+                zout.writestr(name, mem.read())
+    return out_zip_path

--- a/solafune_tools/community_tools/raster_regression/ensemble.py
+++ b/solafune_tools/community_tools/raster_regression/ensemble.py
@@ -1,0 +1,101 @@
+"""Zip-level ensembling for raster regression submissions.
+
+Averaging the predictions of independently trained models is one of the most reliable
+score improvements available in regression competitions, and doing it directly on
+submission archives means it works across teams' pipelines, frameworks, and even
+between your own past submissions — no re-inference needed. A plain 50/50 average of
+two diverse submissions typically beats both inputs.
+"""
+
+import os
+import zipfile
+from io import BytesIO
+from typing import List, Optional, Sequence
+
+import numpy as np
+from tqdm import tqdm
+
+from rasterio.io import MemoryFile
+
+from solafune_tools.community_tools.raster_regression.validation import _tif_names
+
+
+def blend_submission_zips(
+    zip_paths: Sequence[str],
+    out_path: str,
+    weights: Optional[Sequence[float]] = None,
+    clip_min: Optional[float] = 0.0,
+    clip_max: Optional[float] = None,
+    progress: bool = True,
+) -> str:
+    """Blend N submission archives into one by (weighted) pixel-wise averaging.
+
+    Tiles are matched across archives by base file name; every archive must contain
+    the same tile set. Geo metadata (CRS/transform/dtype) is copied from the first
+    archive. Tiles are processed one at a time, so memory stays flat regardless of
+    archive size.
+
+    Args:
+        zip_paths: Two or more submission archives to blend.
+        out_path: Path of the blended archive to write (created/overwritten).
+        weights: Optional per-archive weights; normalized to sum to 1. Default equal.
+        clip_min: Clip blended values below this (default 0.0). ``None`` disables.
+        clip_max: Clip blended values above this. ``None`` disables.
+        progress: Show a tqdm progress bar.
+
+    Returns:
+        ``out_path``.
+
+    Raises:
+        ValueError: On fewer than two archives, weight/archive count mismatch, or
+            tile-set mismatch between archives.
+    """
+    if len(zip_paths) < 2:
+        raise ValueError("Need at least two archives to blend.")
+    if weights is None:
+        w = np.full(len(zip_paths), 1.0 / len(zip_paths))
+    else:
+        if len(weights) != len(zip_paths):
+            raise ValueError("weights and zip_paths must have the same length.")
+        w = np.asarray(weights, dtype="float64")
+        if w.sum() <= 0:
+            raise ValueError("weights must sum to a positive value.")
+        w = w / w.sum()
+
+    archives = [zipfile.ZipFile(p) for p in zip_paths]
+    try:
+        member_maps: List[dict] = []
+        for p, zf in zip(zip_paths, archives):
+            m = {os.path.basename(n): n for n in _tif_names(zf)}
+            if not m:
+                raise ValueError(f"No .tif files found in {p}")
+            member_maps.append(m)
+        base_names = sorted(member_maps[0])
+        for p, m in zip(zip_paths[1:], member_maps[1:]):
+            if sorted(m) != base_names:
+                raise ValueError(f"Tile set in {p} does not match {zip_paths[0]}")
+
+        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as out:
+            iterator = tqdm(base_names, desc="blend", disable=not progress)
+            for name in iterator:
+                blended = None
+                profile = None
+                for wi, zf, m in zip(w, archives, member_maps):
+                    with MemoryFile(BytesIO(zf.read(m[name]))) as mem:
+                        with mem.open() as src:
+                            arr = src.read().astype("float64")
+                            if profile is None:
+                                profile = src.profile.copy()
+                    blended = wi * arr if blended is None else blended + wi * arr
+                if clip_min is not None or clip_max is not None:
+                    blended = np.clip(blended, clip_min, clip_max)
+                profile.update(count=blended.shape[0])
+                dtype = profile.get("dtype", "float32")
+                with MemoryFile() as mem:
+                    with mem.open(**profile) as dst:
+                        dst.write(blended.astype(dtype))
+                    out.writestr(name, mem.read())
+    finally:
+        for zf in archives:
+            zf.close()
+    return out_path

--- a/solafune_tools/community_tools/raster_regression/validation.py
+++ b/solafune_tools/community_tools/raster_regression/validation.py
@@ -1,0 +1,218 @@
+"""Validation helpers for raster (GeoTIFF-zip) regression competition submissions.
+
+Raster regression competitions (e.g. Precipitation Nowcasting From Space) are scored on
+zip archives of GeoTIFF tiles rather than JSON/CSV files, so the existing
+``competition_tools.quality_checker`` validators do not apply. These helpers catch the
+failure modes that silently burn daily submission quota or corrupt scores: missing or
+misnamed tiles, wrong grid shape, NaN/Inf pixels, and out-of-range values.
+
+Error codes follow the ``quality_checker`` convention (0 = valid, one code per failure
+mode) so they can be dispatched the same way.
+"""
+
+import os
+import zipfile
+from io import BytesIO
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    import rasterio
+    from rasterio.io import MemoryFile
+except ImportError as _err:  # pragma: no cover
+    raise ImportError("raster_regression tools require rasterio: pip install rasterio") from _err
+
+ERROR_MESSAGES = {
+    0: "Valid",
+    30: "Cannot open the zip archive.",
+    31: "No .tif files found inside the archive.",
+    32: "Tile count mismatch against the reference archive.",
+    33: "Tile file names do not match the reference archive.",
+    34: "One or more tiles could not be read as GeoTIFF.",
+    35: "One or more tiles have an unexpected raster shape.",
+    36: "One or more tiles contain NaN or Inf pixels.",
+    37: "One or more tiles contain values outside the allowed range.",
+}
+
+
+def return_error_message(error_code: int) -> str:
+    """Map a raster-submission error code to a human-readable message."""
+    return ERROR_MESSAGES.get(error_code, "Unknown error, contact the developer for more information.")
+
+
+def _tif_names(zf: zipfile.ZipFile) -> List[str]:
+    """All .tif/.tiff member paths in the archive (directories excluded)."""
+    return [
+        n for n in zf.namelist()
+        if n.lower().endswith((".tif", ".tiff")) and not n.endswith("/")
+    ]
+
+
+def _read_member(zf: zipfile.ZipFile, name: str) -> np.ndarray:
+    """Read one archive member as a (bands, H, W) float64 array."""
+    with MemoryFile(BytesIO(zf.read(name))) as mem:
+        with mem.open() as src:
+            return src.read().astype("float64")
+
+
+def validate_submission_zip(
+    pred_zip_path: str,
+    reference_zip_path: Optional[str] = None,
+    expected_shape: Optional[Tuple[int, ...]] = None,
+    value_min: Optional[float] = 0.0,
+    value_max: Optional[float] = None,
+    max_report_items: int = 20,
+) -> Tuple[int, Dict]:
+    """Validate a prediction zip before uploading it.
+
+    Args:
+        pred_zip_path: Path to the submission archive to check.
+        reference_zip_path: Optional sample-submission archive. When given, the
+            prediction must contain exactly the same tile file names (paths are
+            compared by base name, so an extra top-level folder is fine).
+        expected_shape: Optional required raster shape. Give ``(H, W)`` to require
+            single-band tiles of that grid, or ``(bands, H, W)`` to also pin the
+            band count. When omitted and a reference is given, each tile is checked
+            against the shape of the reference tile of the same name.
+        value_min: Lowest allowed pixel value (default 0.0 — negative rain/cost/mass
+            predictions are almost always a bug). Pass ``None`` to skip.
+        value_max: Highest allowed pixel value. Pass ``None`` to skip.
+        max_report_items: Cap on offending file names listed per problem.
+
+    Returns:
+        (error_code, report) — ``error_code`` 0 means uploadable. ``report`` carries
+        the offending file names per check, plus ``stats`` (tile count, global
+        min/max/mean, all-zero tile count) and non-fatal ``warnings``.
+    """
+    report: Dict = {"stats": {}, "warnings": []}
+
+    try:
+        zf = zipfile.ZipFile(pred_zip_path)
+    except (OSError, zipfile.BadZipFile):
+        return 30, report
+
+    with zf:
+        names = sorted(_tif_names(zf))
+        if not names:
+            return 31, report
+        report["stats"]["n_tiles"] = len(names)
+
+        ref_shapes: Dict[str, Tuple[int, ...]] = {}
+        if reference_zip_path is not None:
+            try:
+                ref = zipfile.ZipFile(reference_zip_path)
+            except (OSError, zipfile.BadZipFile):
+                return 30, report
+            with ref:
+                ref_names = sorted(_tif_names(ref))
+                if len(names) != len(ref_names):
+                    report["expected_n_tiles"] = len(ref_names)
+                    return 32, report
+                pred_base = {os.path.basename(n): n for n in names}
+                missing = [os.path.basename(n) for n in ref_names
+                           if os.path.basename(n) not in pred_base]
+                if missing:
+                    report["missing_files"] = missing[:max_report_items]
+                    return 33, report
+                if expected_shape is None:
+                    for n in ref_names:
+                        with MemoryFile(BytesIO(ref.read(n))) as mem:
+                            with mem.open() as src:
+                                ref_shapes[os.path.basename(n)] = (src.count, src.height, src.width)
+
+        unreadable, bad_shape, non_finite, out_of_range = [], [], [], []
+        gmin, gmax, gsum, gcount, all_zero = np.inf, -np.inf, 0.0, 0, 0
+
+        for n in names:
+            try:
+                arr = _read_member(zf, n)
+            except Exception:
+                unreadable.append(n)
+                continue
+
+            shape_ok = True
+            if expected_shape is not None:
+                want = tuple(expected_shape)
+                if len(want) == 2:
+                    shape_ok = arr.shape[0] == 1 and arr.shape[1:] == want
+                else:
+                    shape_ok = arr.shape == want
+            elif ref_shapes:
+                shape_ok = arr.shape == ref_shapes.get(os.path.basename(n), arr.shape)
+            if not shape_ok:
+                bad_shape.append((n, arr.shape))
+
+            if not np.isfinite(arr).all():
+                non_finite.append(n)
+                continue
+
+            amin, amax = float(arr.min()), float(arr.max())
+            if (value_min is not None and amin < value_min) or \
+               (value_max is not None and amax > value_max):
+                out_of_range.append((n, amin, amax))
+            gmin, gmax = min(gmin, amin), max(gmax, amax)
+            gsum += float(arr.sum())
+            gcount += arr.size
+            if amax == 0.0 and amin == 0.0:
+                all_zero += 1
+
+        report["stats"].update({
+            "value_min": None if gcount == 0 else gmin,
+            "value_max": None if gcount == 0 else gmax,
+            "value_mean": None if gcount == 0 else gsum / gcount,
+            "all_zero_tiles": all_zero,
+        })
+        if all_zero:
+            report["warnings"].append(
+                f"{all_zero} tiles are entirely zero — expected for dry scenes, "
+                "but verify if the count looks high."
+            )
+
+        for code, items, key in (
+            (34, unreadable, "unreadable"),
+            (35, bad_shape, "bad_shape"),
+            (36, non_finite, "non_finite"),
+            (37, out_of_range, "out_of_range"),
+        ):
+            if items:
+                report[key] = items[:max_report_items]
+                return code, report
+
+    return 0, report
+
+
+def band_count_report(
+    data_dir: str,
+    expected_bands: int,
+    pattern: str = ".tif",
+) -> List[Tuple[str, int, Tuple[int, ...]]]:
+    """List dataset tiles whose band count differs from ``expected_bands``.
+
+    Some competition tiles ship with fewer bands than nominal (e.g. GOES tiles missing
+    their visible channels), and the GeoTIFF itself carries no record of *which* bands
+    are absent — naive channel indexing then reads the wrong band for every channel of
+    the tile. Run this once over a dataset directory to find such tiles so you can
+    exclude or special-case them.
+
+    Args:
+        data_dir: Directory scanned recursively for raster files.
+        expected_bands: Nominal band count (e.g. 16 for full-disk geostationary stacks).
+        pattern: File-name suffix filter.
+
+    Returns:
+        List of ``(path, band_count, (bands, H, W))`` for every deviating tile.
+    """
+    deviant = []
+    for root, _dirs, files in os.walk(data_dir):
+        for f in sorted(files):
+            if not f.lower().endswith(pattern):
+                continue
+            path = os.path.join(root, f)
+            try:
+                with rasterio.open(path) as src:
+                    if src.count != expected_bands:
+                        deviant.append((path, src.count, (src.count, src.height, src.width)))
+            except Exception:
+                deviant.append((path, -1, ()))
+    return deviant

--- a/tests/test_raster_regression.py
+++ b/tests/test_raster_regression.py
@@ -1,0 +1,269 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from io import BytesIO
+
+import numpy as np
+import rasterio
+from rasterio.io import MemoryFile
+
+from solafune_tools.community_tools.raster_regression import (
+    IsotonicCalibrator,
+    band_count_report,
+    blend_submission_zips,
+    calibrate_submission_zip,
+    return_error_message,
+    validate_submission_zip,
+)
+
+
+def _tif_bytes(arr: np.ndarray) -> bytes:
+    """Encode a (bands, H, W) float32 array as an in-memory GeoTIFF."""
+    arr = arr.astype("float32")
+    with MemoryFile() as mem:
+        with mem.open(
+            driver="GTiff", count=arr.shape[0], height=arr.shape[1],
+            width=arr.shape[2], dtype="float32",
+        ) as dst:
+            dst.write(arr)
+        return mem.read()
+
+
+def _make_zip(path: str, tiles: dict) -> str:
+    """Write {name: (bands,H,W) array} into a zip of GeoTIFFs."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, arr in tiles.items():
+            zf.writestr(name, _tif_bytes(np.asarray(arr)))
+    return path
+
+
+def _read_zip_tile(path: str, name: str) -> np.ndarray:
+    with zipfile.ZipFile(path) as zf:
+        with MemoryFile(BytesIO(zf.read(name))) as mem:
+            with mem.open() as src:
+                return src.read()
+
+
+class RasterRegressionBase(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        rng = np.random.RandomState(0)
+        self.tiles = {
+            f"tile_{i:02d}.tif": rng.rand(1, 8, 8) * 10 for i in range(4)
+        }
+        self.pred_zip = _make_zip(os.path.join(self.dir, "pred.zip"), self.tiles)
+        self.ref_zip = _make_zip(
+            os.path.join(self.dir, "ref.zip"),
+            {n: np.zeros((1, 8, 8)) for n in self.tiles},
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+class TestValidation(RasterRegressionBase):
+    def test_valid_submission(self):
+        code, report = validate_submission_zip(self.pred_zip, self.ref_zip)
+        self.assertEqual(code, 0)
+        self.assertEqual(report["stats"]["n_tiles"], 4)
+        self.assertEqual(return_error_message(code), "Valid")
+
+    def test_bad_zip(self):
+        bad = os.path.join(self.dir, "not_a_zip.zip")
+        with open(bad, "wb") as f:
+            f.write(b"hello")
+        code, _ = validate_submission_zip(bad)
+        self.assertEqual(code, 30)
+
+    def test_empty_zip(self):
+        empty = os.path.join(self.dir, "empty.zip")
+        with zipfile.ZipFile(empty, "w") as zf:
+            zf.writestr("readme.txt", "no rasters here")
+        code, _ = validate_submission_zip(empty)
+        self.assertEqual(code, 31)
+
+    def test_count_mismatch(self):
+        subset = {k: v for k, v in list(self.tiles.items())[:2]}
+        small = _make_zip(os.path.join(self.dir, "small.zip"), subset)
+        code, report = validate_submission_zip(small, self.ref_zip)
+        self.assertEqual(code, 32)
+        self.assertEqual(report["expected_n_tiles"], 4)
+
+    def test_name_mismatch(self):
+        renamed = dict(self.tiles)
+        renamed["wrong_name.tif"] = renamed.pop("tile_00.tif")
+        bad = _make_zip(os.path.join(self.dir, "renamed.zip"), renamed)
+        code, report = validate_submission_zip(bad, self.ref_zip)
+        self.assertEqual(code, 33)
+        self.assertIn("tile_00.tif", report["missing_files"])
+
+    def test_folder_prefix_is_accepted(self):
+        nested = {f"submission/{n}": a for n, a in self.tiles.items()}
+        z = _make_zip(os.path.join(self.dir, "nested.zip"), nested)
+        code, _ = validate_submission_zip(z, self.ref_zip)
+        self.assertEqual(code, 0)
+
+    def test_shape_mismatch(self):
+        bad_tiles = dict(self.tiles)
+        bad_tiles["tile_00.tif"] = np.zeros((1, 4, 4))
+        z = _make_zip(os.path.join(self.dir, "badshape.zip"), bad_tiles)
+        code, report = validate_submission_zip(z, expected_shape=(8, 8))
+        self.assertEqual(code, 35)
+        self.assertEqual(report["bad_shape"][0][0], "tile_00.tif")
+
+    def test_nan_detected(self):
+        bad_tiles = dict(self.tiles)
+        arr = np.ones((1, 8, 8))
+        arr[0, 3, 3] = np.nan
+        bad_tiles["tile_01.tif"] = arr
+        z = _make_zip(os.path.join(self.dir, "nan.zip"), bad_tiles)
+        code, report = validate_submission_zip(z)
+        self.assertEqual(code, 36)
+        self.assertIn("tile_01.tif", report["non_finite"])
+
+    def test_negative_detected(self):
+        bad_tiles = dict(self.tiles)
+        bad_tiles["tile_02.tif"] = np.full((1, 8, 8), -1.0)
+        z = _make_zip(os.path.join(self.dir, "neg.zip"), bad_tiles)
+        code, report = validate_submission_zip(z)
+        self.assertEqual(code, 37)
+        self.assertEqual(report["out_of_range"][0][0], "tile_02.tif")
+
+    def test_all_zero_warning(self):
+        code, report = validate_submission_zip(self.ref_zip)
+        self.assertEqual(code, 0)
+        self.assertEqual(report["stats"]["all_zero_tiles"], 4)
+        self.assertTrue(report["warnings"])
+
+    def test_band_count_report(self):
+        d = os.path.join(self.dir, "dataset")
+        os.makedirs(d)
+        full = np.zeros((16, 8, 8), dtype="float32")
+        short = np.zeros((12, 8, 8), dtype="float32")
+        for name, arr in (("full.tif", full), ("short.tif", short)):
+            with rasterio.open(
+                os.path.join(d, name), "w", driver="GTiff", count=arr.shape[0],
+                height=8, width=8, dtype="float32",
+            ) as dst:
+                dst.write(arr)
+        deviant = band_count_report(d, expected_bands=16)
+        self.assertEqual(len(deviant), 1)
+        self.assertTrue(deviant[0][0].endswith("short.tif"))
+        self.assertEqual(deviant[0][1], 12)
+
+
+class TestEnsemble(RasterRegressionBase):
+    def test_equal_blend_is_mean(self):
+        tiles_b = {n: a + 2.0 for n, a in self.tiles.items()}
+        zb = _make_zip(os.path.join(self.dir, "b.zip"), tiles_b)
+        out = blend_submission_zips(
+            [self.pred_zip, zb], os.path.join(self.dir, "blend.zip"), progress=False,
+        )
+        got = _read_zip_tile(out, "tile_00.tif")
+        want = (self.tiles["tile_00.tif"] + tiles_b["tile_00.tif"]) / 2.0
+        np.testing.assert_allclose(got, want.astype("float32"), rtol=1e-6)
+
+    def test_weighted_blend(self):
+        tiles_b = {n: np.zeros_like(a) for n, a in self.tiles.items()}
+        zb = _make_zip(os.path.join(self.dir, "b.zip"), tiles_b)
+        out = blend_submission_zips(
+            [self.pred_zip, zb], os.path.join(self.dir, "wblend.zip"),
+            weights=[3.0, 1.0], progress=False,
+        )
+        got = _read_zip_tile(out, "tile_00.tif")
+        want = 0.75 * self.tiles["tile_00.tif"]
+        np.testing.assert_allclose(got, want.astype("float32"), rtol=1e-6)
+
+    def test_clip_floor(self):
+        neg = {n: a - 100.0 for n, a in self.tiles.items()}
+        za = _make_zip(os.path.join(self.dir, "na.zip"), neg)
+        zb = _make_zip(os.path.join(self.dir, "nb.zip"), neg)
+        out = blend_submission_zips(
+            [za, zb], os.path.join(self.dir, "clip.zip"), progress=False,
+        )
+        self.assertGreaterEqual(_read_zip_tile(out, "tile_00.tif").min(), 0.0)
+
+    def test_mismatched_tiles_raise(self):
+        other = _make_zip(
+            os.path.join(self.dir, "other.zip"), {"different.tif": np.zeros((1, 8, 8))},
+        )
+        with self.assertRaises(ValueError):
+            blend_submission_zips(
+                [self.pred_zip, other], os.path.join(self.dir, "x.zip"), progress=False,
+            )
+
+    def test_single_zip_raises(self):
+        with self.assertRaises(ValueError):
+            blend_submission_zips([self.pred_zip], os.path.join(self.dir, "x.zip"))
+
+
+class TestCalibration(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def test_recovers_monotone_distortion(self):
+        # Model predicts sqrt of the truth (tail under-prediction, as with MSE on
+        # skewed targets); isotonic calibration must approximately invert it.
+        rng = np.random.RandomState(1)
+        true = rng.gamma(shape=1.0, scale=3.0, size=200_000)
+        pred = np.sqrt(true)
+        cal = IsotonicCalibrator(n_bins=64).fit(pred, true)
+        test_true = rng.gamma(shape=1.0, scale=3.0, size=50_000)
+        test_pred = np.sqrt(test_true)
+        rmse_before = np.sqrt(np.mean((test_pred - test_true) ** 2))
+        rmse_after = np.sqrt(np.mean((cal.transform(test_pred) - test_true) ** 2))
+        self.assertLess(rmse_after, rmse_before * 0.35)
+
+    def test_mapping_is_monotone(self):
+        rng = np.random.RandomState(2)
+        pred = rng.rand(10_000)
+        true = -pred + rng.rand(10_000) * 5  # anti-correlated noise stresses PAVA
+        cal = IsotonicCalibrator(n_bins=32).fit(pred, true)
+        self.assertTrue(np.all(np.diff(cal.y_) >= -1e-12))
+
+    def test_save_load_roundtrip(self):
+        rng = np.random.RandomState(3)
+        pred = rng.rand(5_000) * 4
+        cal = IsotonicCalibrator(n_bins=16).fit(pred, pred * 2)
+        path = os.path.join(self.dir, "cal.json")
+        cal.save(path)
+        loaded = IsotonicCalibrator.load(path)
+        x = rng.rand(100) * 4
+        np.testing.assert_allclose(cal.transform(x), loaded.transform(x))
+        with open(path) as f:
+            self.assertEqual(json.load(f)["n_bins"], 16)
+
+    def test_constant_predictions(self):
+        pred = np.full(1000, 2.0)
+        cal = IsotonicCalibrator(n_bins=8).fit(pred, np.full(1000, 5.0))
+        np.testing.assert_allclose(cal.transform(np.array([2.0])), [5.0])
+
+    def test_calibrate_zip_grouped(self):
+        tiles = {
+            "sat_a_tile0.tif": np.full((1, 4, 4), 1.0),
+            "sat_b_tile0.tif": np.full((1, 4, 4), 1.0),
+        }
+        zin = _make_zip(os.path.join(self.dir, "in.zip"), tiles)
+        rng = np.random.RandomState(4)
+        pred = rng.rand(2_000) * 2
+        cal_double = IsotonicCalibrator(n_bins=16).fit(pred, pred * 2)
+        out = calibrate_submission_zip(
+            zin, os.path.join(self.dir, "out.zip"),
+            calibrator={"sat_a": cal_double},
+            group_fn=lambda name: name.split("_tile")[0],
+            progress=False,
+        )
+        a = _read_zip_tile(out, "sat_a_tile0.tif")
+        b = _read_zip_tile(out, "sat_b_tile0.tif")
+        np.testing.assert_allclose(a, np.full((1, 4, 4), 2.0), rtol=1e-2)
+        np.testing.assert_allclose(b, np.full((1, 4, 4), 1.0))  # no calibrator: unchanged
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `solafune_tools.community_tools.raster_regression` — tools for competitions scored on **zip archives of GeoTIFF tiles** (raster regression), such as the ongoing *Precipitation Nowcasting From Space* competition. The existing `competition_tools` validators cover JSON (bbox/segmentation) and CSV submissions; this fills the raster gap.

## Contents

- **`validate_submission_zip` / `return_error_message`** — pre-upload submission checking: tile count/names vs. the sample submission, raster shapes, NaN/Inf pixels, negative values. Error codes follow the `quality_checker` convention (0 = valid, 30–37 per failure mode). Catches format rejects before they burn a daily submission slot.
- **`blend_submission_zips`** — pixel-wise (weighted) averaging of N submission archives, streamed tile-by-tile so memory stays flat. Artifact-level ensembling works across pipelines/frameworks with no re-inference; in the precipitation competition a 50/50 blend of two diverse submissions improved our leaderboard RMSE over either input.
- **`IsotonicCalibrator` / `calibrate_submission_zip`** — isotonic output calibration via pool-adjacent-violators, fit on out-of-fold predictions, with optional per-group calibrators (e.g. one per satellite, routed by file name). No scikit-learn dependency. Corrects the systematic heavy-tail under-prediction of MSE-trained models on skewed targets; per-satellite calibration was a durable leaderboard improvement in our pipeline.
- **`band_count_report`** — scans a dataset for tiles whose band count deviates from nominal (GeoTIFFs don't record *which* bands are missing, so positional indexing silently misaligns such tiles).

## Compliance with the PR guidelines

- **No new dependencies** — numpy / rasterio / tqdm only (all already in `requirements/base.txt`).
- **Tests**: `tests/test_raster_regression.py`, 21 unit tests on synthetic in-memory GeoTIFF fixtures (no competition data anywhere in the PR). All existing tests still pass.
- **Docs**: module README (per the community_tools template) + `docs/community_tools/raster_regression.md` usage page; both tool indexes updated.
- **Originality**: original code. PAVA follows Barlow, Bartholomew, Bremner & Brunk (1972), *Statistical Inference under Order Restrictions*. Developed with assistance from Claude (Anthropic), acknowledged in the docs per guideline 4.1.

A discussion topic explaining the tools will be posted on the Precipitation Nowcasting From Space competition forum, linking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)